### PR TITLE
Adds testimonials to the CMS config

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -126,3 +126,26 @@ collections:
         multiple: true
         options: ['2015', '2016', '2017', '2018', '2019', '2020']
         required: false
+
+  - name: 'testimonials'
+    label: 'Testimonials'
+    identifier_field: quote
+    label_singular: 'Testimonial'
+    description: 'Add, edit, or delete testimonials here. Testimonials will be shown across the website.'
+    delete: true
+    create: true
+    folder: 'content/testimonials'
+    extension: 'json'
+    fields:
+      - label: 'Quote'
+        name: 'quote'
+        widget: 'text'
+        required: true
+      - label: 'Name'
+        name: 'name'
+        widget: 'string'
+        required: true
+      - label: 'URL Source'
+        name: 'url_source'
+        widget: 'string'
+        required: false


### PR DESCRIPTION
### Closes #42 

We want to be able to showcase different testimonials from members in our community on different sections of the website. We can keep a collection of them in the CMS that we can then query for on different pages.

### Proposed changes

- Adds `testimonials` collection to the CMS' config.yml

### Acceptance criteria

- [x] Testimonials Collection exists in the CMS
- [x] Testimonials have fields for: quote (text, required), name (string, required), url_source (string, required)

### Requested feedback

- I chose to use the `quote` field as the unique identifier. What do you think?
