### PR TITLE
Fixed Miriam's Twitter handle

### DIFF
--- a/content/speakers/miriam-aguirre.json
+++ b/content/speakers/miriam-aguirre.json
@@ -7,7 +7,7 @@
   "links": [
     {
       "type": "twitter",
-      "url": "techaquirre"
+      "url": "techaguirre"
     },
     {
       "type": "linkedin",


### PR DESCRIPTION
### Proposed changes

- Miriam Aguirre's twitter handle should be twitter.com/techa**g**uirre and not twitter.com/techa**q**uirre.

<!-- Optional: Add detailed discussion of changes here -->
<!-- Optional: Add screenshots (drag images here) -->

### Acceptance criteria

<!-- Copy the acceptance criteria from the ticket and mark if you were able to complete them -->

- [x] Fulfilled Acceptance Criteria

  <!-- If not, why not? -->

- [ ] Tests added to cover the change

Didn't add test.

### Requested feedback

Please let me know if there's anything I need to change. Thanks!