### PR TITLE
Remove a CSS hack for font awesome icons

### DIFF
--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -1,9 +1,4 @@
 import React from 'react'
-// This ensures that the icon CSS is loaded immediately before attempting to render icons
-import '@fortawesome/fontawesome-svg-core/styles.css'
-import { config } from '@fortawesome/fontawesome-svg-core'
-// Prevent fontawesome from dynamically adding its css since we did it manually above
-config.autoAddCss = false
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faExternalLinkAlt, faFilePdf } from '@fortawesome/free-solid-svg-icons'
 import { faMeetup } from '@fortawesome/free-brands-svg-icons'

--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -1,9 +1,4 @@
 import React, { useState } from 'react'
-// This ensures that the icon CSS is loaded immediately before attempting to render icons
-import '@fortawesome/fontawesome-svg-core/styles.css'
-import { config } from '@fortawesome/fontawesome-svg-core'
-// Prevent fontawesome from dynamically adding its css since we did it manually above
-config.autoAddCss = false
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { navigate } from 'gatsby'


### PR DESCRIPTION
### Closes #XXXX

The site was reporting errors when trying to run `npm run develop`
```
   7:1  error  Import in body of module; reorder to top  import/first
   8:1  error  Import in body of module; reorder to top  import/first
   9:1  error  Import in body of module; reorder to top  import/first
  11:1  error  Import in body of module; reorder to top  import/first

✖ 4 problems (4 errors, 0 warnings)
  4 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Proposed changes

- Removes the CSS hack from two files that were causing the site not to build

