### PR TITLE
Remove external link icon next to links

### DIFF
--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExternalLinkAlt, faFilePdf } from '@fortawesome/free-solid-svg-icons'
+import { faFilePdf } from '@fortawesome/free-solid-svg-icons'
 import { faMeetup } from '@fortawesome/free-brands-svg-icons'
 
 export const ExternalLink = ({ href, text, icon }) => {
@@ -11,16 +11,14 @@ export const ExternalLink = ({ href, text, icon }) => {
       case 'meetup':
         return faMeetup
       default:
-        return faExternalLinkAlt
+        return null
     }
   }
 
   return (
     <a href={href} className="link" target="_blank" rel="noopener noreferrer">
       {text}&nbsp;
-      <span style={{ display: 'inlineBlock', maxWidth: '1em' }}>
-        <FontAwesomeIcon icon={setIcon()} aria-hidden />
-      </span>
+      <FontAwesomeIcon icon={setIcon()} aria-hidden />
     </a>
   )
 }

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -18,7 +18,9 @@ export const ExternalLink = ({ href, text, icon }) => {
   return (
     <a href={href} className="link" target="_blank" rel="noopener noreferrer">
       {text}&nbsp;
-      <FontAwesomeIcon icon={setIcon()} aria-hidden />
+      <span style={{ width: '1em' }}>
+        <FontAwesomeIcon icon={setIcon()} aria-hidden />
+      </span>
     </a>
   )
 }

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -18,7 +18,7 @@ export const ExternalLink = ({ href, text, icon }) => {
   return (
     <a href={href} className="link" target="_blank" rel="noopener noreferrer">
       {text}&nbsp;
-      <span style={{ width: '1em' }}>
+      <span style={{ display: 'inlineBlock', maxWidth: '1em' }}>
         <FontAwesomeIcon icon={setIcon()} aria-hidden />
       </span>
     </a>


### PR DESCRIPTION
Remove external link icon next to links for now because for some reason it loads super large and flashes before becoming small on the home page above the fold.

